### PR TITLE
Add telemetry and evaluation instrumentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,22 @@
+# Environment configuration for Granite SQE telemetry.
+#
+# Copy this file to `.env` and adjust the values as needed. Keep your secrets
+# (such as WANDB_API_KEY) out of source control—configure them via your local
+# environment or CI secrets.
+
+# Enable Weights & Biases tracking (defaults to disabled)
+# ENABLE_WANDB=true
+# WANDB_PROJECT=granite-moe-experiments
+# WANDB_ENTITY=quality-engineering
+# WANDB_RUN_NAME=granite-trial
+# WANDB_TAGS=baseline,granite
+
+# Enable TensorBoard logging (defaults to disabled)
+# ENABLE_TENSORBOARD=true
+# TB_LOG_DIR=./runs
+
+# Optional: override telemetry logging interval (in steps)
+# LOG_INTERVAL_STEPS=25
+
+# W&B authentication should be configured via WANDB_API_KEY in your shell or CI
+# secret store. Never commit the API key to this repository.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ venv/
 chroma_db/
 output/
 cache/
+runs/
+artifacts/
 
 # Build artifacts
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: tb train test
+
+train:
+	python train.py
+
+tb:
+	./scripts/tensorboard.sh
+
+test:
+	pytest -q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Granite SQE Agent
+
+This repository contains the Granite Software Quality Engineering agent, training harness, and supporting utilities for generating and evaluating test artefacts. The project now includes opt-in telemetry instrumentation so experiments can be tracked with Weights & Biases (W&B) and visualised in TensorBoard.
+
+## Telemetry & Evaluation
+
+Telemetry is disabled by default. Enable it per run via CLI flags or environment variables. The configuration is managed through `TelemetryConfig` (see `src/config/telemetry.py`) and used by the training harness (`train.py`) and evaluation pipeline (`src/eval/evaluate.py`).
+
+### CLI Flags
+
+```bash
+# Enable both W&B and TensorBoard
+python train.py --task-type classification --epochs 2 \
+  --enable-wandb --wandb-project granite-moe \
+  --enable-tensorboard --tb-log-dir ./runs/demo
+```
+
+Key flags:
+
+- `--enable-wandb` / `--disable-wandb`
+- `--wandb-project`, `--wandb-entity`, `--wandb-run-name`, `--wandb-tags`
+- `--enable-tensorboard` / `--disable-tensorboard`
+- `--tb-log-dir`
+- `--log-checkpoints` to upload model checkpoints when telemetry is enabled
+
+### Environment Variables
+
+Environment variables offer the same controls and remain opt-in:
+
+- `ENABLE_WANDB`, `WANDB_PROJECT`, `WANDB_ENTITY`, `WANDB_RUN_NAME`, `WANDB_TAGS`
+- `ENABLE_TENSORBOARD`, `TB_LOG_DIR`
+- `LOG_INTERVAL_STEPS` to adjust telemetry cadence
+
+Copy `.env.sample` to `.env` for local development, but never commit secrets. Configure `WANDB_API_KEY` through your shell or CI secrets store.
+
+### TensorBoard
+
+Launch TensorBoard with the provided script or Makefile target:
+
+```bash
+make tb
+# or
+./scripts/tensorboard.sh
+```
+
+### Evaluation Pipeline
+
+The reusable evaluation utilities live under `src/eval/`. Use `evaluate` to compute metrics for classification, regression, or text-generation tasks and automatically persist an `eval_report.json`. When telemetry is enabled, the report is uploaded as a run artifact.
+
+## GitHub Actions Notes
+
+When enabling telemetry in CI:
+
+1. Add a repository secret named `WANDB_API_KEY`.
+2. Export it in the workflow step before running training:
+
+   ```yaml
+   - name: Configure W&B
+     run: |
+       echo "WANDB_API_KEY=${WANDB_API_KEY}" >> "$GITHUB_ENV"
+     env:
+       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+   ```
+3. Opt into telemetry with CLI flags or environment variables in the training step.
+
+Upload artifacts (e.g., `artifacts/eval/eval_report.json` or checkpoints) with `actions/upload-artifact` if you need them outside of W&B.
+
+## Example Runs
+
+```bash
+# Run the synthetic training loop without telemetry
+python train.py --task-type classification --epochs 1
+
+# Enable W&B with tags and checkpoint uploads
+WANDB_PROJECT=granite-experiments ENABLE_WANDB=true \
+python train.py --task-type regression --epochs 2 --log-checkpoints
+
+# Evaluate an existing model via the helper (imports evaluate())
+python -c "from src.eval.evaluate import evaluate; print('See tests for examples')"
+```
+
+Refer to the docstrings in `src/telemetry/experiment.py` and `src/eval/metrics.py` for extension guidelines.

--- a/granite-test-generator/requirements.txt
+++ b/granite-test-generator/requirements.txt
@@ -192,3 +192,7 @@ zstandard==0.25.0
 pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-cov==7.0.0
+tensorboard>=2.16
+wandb>=0.17
+evaluate>=0.4.2
+torchmetrics>=1.4

--- a/granite-test-generator/src/config/__init__.py
+++ b/granite-test-generator/src/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration utilities for the Granite SQE agent."""
+
+from .telemetry import TelemetryConfig, load_telemetry_from_sources
+
+__all__ = ["TelemetryConfig", "load_telemetry_from_sources"]

--- a/granite-test-generator/src/eval/__init__.py
+++ b/granite-test-generator/src/eval/__init__.py
@@ -1,0 +1,28 @@
+"""Evaluation utilities package with lazy imports."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .metrics import (
+    compute_classification_metrics,
+    compute_regression_metrics,
+    compute_text_generation_metrics,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .evaluate import evaluate as evaluate_fn
+
+
+def evaluate(*args: Any, **kwargs: Any):
+    from .evaluate import evaluate as _evaluate
+
+    return _evaluate(*args, **kwargs)
+
+
+__all__ = [
+    "compute_classification_metrics",
+    "compute_regression_metrics",
+    "compute_text_generation_metrics",
+    "evaluate",
+]

--- a/granite-test-generator/src/eval/evaluate.py
+++ b/granite-test-generator/src/eval/evaluate.py
@@ -1,0 +1,188 @@
+"""Evaluation loop helpers integrated with the experiment telemetry stack."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+try:  # pragma: no cover - optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - fallback when torch unavailable
+    torch = None  # type: ignore
+
+from src.telemetry import ExperimentLogger
+
+from .metrics import (
+    compute_classification_metrics,
+    compute_regression_metrics,
+    compute_text_generation_metrics,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def evaluate(
+    model: Any,
+    dataloader: Iterable,
+    task_type: str,
+    device: Optional[str] = None,
+    experiment_logger: Optional[ExperimentLogger] = None,
+    output_dir: Path | str = Path("artifacts/eval"),
+    epoch: Optional[int] = None,
+) -> Dict[str, float]:
+    """Run model evaluation and persist metrics and artifacts."""
+    device = device or ("cuda" if torch is not None and torch.cuda.is_available() else "cpu")
+    if torch is not None and hasattr(model, "to"):
+        model = model.to(device)  # type: ignore[assignment]
+    if hasattr(model, "eval"):
+        model.eval()  # type: ignore[attr-defined]
+    results: MutableMapping[str, float] = {}
+
+    predictions: list[Any] = []
+    targets: list[Any] = []
+    probabilities: list[Any] = []
+    latencies_ms: list[float] = []
+
+    forward_ctx = torch.no_grad if torch is not None else nullcontext  # type: ignore[assignment]
+
+    for step, batch in enumerate(dataloader, start=1):
+        inputs, labels = _split_batch(batch)
+        start = time.perf_counter()
+        with forward_ctx():  # type: ignore[operator]
+            preds = _forward(model, inputs, device)
+        latency_ms = (time.perf_counter() - start) * 1000.0
+        latencies_ms.append(latency_ms)
+        LOGGER.debug("Eval step %s latency %.3fms", step, latency_ms)
+
+        if isinstance(preds, tuple):
+            primary, secondary = preds
+        else:
+            primary, secondary = preds, None
+
+        primary_items = _flatten(primary)
+        predictions.extend(primary_items)
+
+        if secondary is not None:
+            secondary_items = _flatten_probabilities(secondary, len(primary_items))
+            probabilities.extend(secondary_items)
+
+        targets.extend(_flatten(labels))
+
+    if task_type == "classification":
+        probs_iter = probabilities if probabilities else None
+        metrics = compute_classification_metrics(predictions, targets, probs_iter)
+    elif task_type == "regression":
+        metrics = compute_regression_metrics(predictions, targets)
+    elif task_type == "text":
+        metrics = compute_text_generation_metrics(
+            [str(pred) for pred in predictions],
+            [[str(label)] if not isinstance(label, (list, tuple)) else label for label in targets],
+            latencies_ms=latencies_ms,
+        )
+    else:
+        raise ValueError(f"Unsupported task type: {task_type}")
+
+    if task_type != "text":
+        metrics["latency_ms_avg"] = float(sum(latencies_ms) / max(len(latencies_ms), 1))
+        metrics["latency_ms_p95"] = float(_percentile(latencies_ms, 95))
+
+    results.update({key: float(value) for key, value in metrics.items() if _is_number(value)})
+
+    step_index = epoch if epoch is not None else len(predictions)
+    if experiment_logger is not None:
+        experiment_logger.log_metrics(step_index, **results)
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    report_path = output_path / "eval_report.json"
+    with open(report_path, "w", encoding="utf-8") as handle:
+        json.dump(results, handle, indent=2)
+    LOGGER.info("Saved evaluation report to %s", report_path)
+
+    if experiment_logger is not None:
+        experiment_logger.log_artifact(report_path, name="eval_report")
+        experiment_logger.set_summary(**results)
+
+    return dict(results)
+
+
+def _split_batch(batch: Any) -> tuple[Any, Any]:
+    """Split supported batch structures into (inputs, labels)."""
+    if isinstance(batch, Mapping):
+        labels = batch.get("labels") or batch.get("targets")
+        inputs = batch.get("inputs") or batch.get("features")
+        if inputs is None or labels is None:
+            raise ValueError("Batch mapping must contain 'inputs'/'labels' keys")
+        return inputs, labels
+    if isinstance(batch, (list, tuple)) and len(batch) == 2:
+        return batch[0], batch[1]
+    raise TypeError("Unsupported batch structure for evaluation")
+
+
+def _forward(model: Any, inputs: Any, device: str) -> Any:
+    """Execute a forward pass for arbitrary model call styles."""
+    if hasattr(model, "eval_step"):
+        return model.eval_step(inputs, device=device)
+    if callable(model):
+        if torch is not None and isinstance(inputs, torch.Tensor):
+            return model(inputs.to(device))
+        return model(inputs)
+    raise TypeError("Model must implement 'eval_step' or be callable")
+
+
+def _flatten(value: Any) -> list[Any]:
+    """Flatten nested containers and tensors into a simple list."""
+    if torch is not None and isinstance(value, torch.Tensor):
+        return value.detach().cpu().flatten().tolist()
+    if isinstance(value, (list, tuple)) and not isinstance(value, (str, bytes)):
+        flattened: list[Any] = []
+        for item in value:
+            flattened.extend(_flatten(item))
+        return flattened
+    return [value]
+
+
+def _flatten_probabilities(value: Any, expected_length: int) -> list[Any]:
+    """Flatten probability-like outputs while respecting sample counts."""
+    if torch is not None and isinstance(value, torch.Tensor):
+        array = value.detach().cpu().flatten().tolist()
+        if len(array) == expected_length:
+            return array
+        if len(array) == 2:
+            return [array[1]]
+        return array
+    if isinstance(value, (list, tuple)):
+        if len(value) == expected_length and not any(isinstance(item, (list, tuple)) for item in value):
+            return list(value)
+        if len(value) == 2 and not isinstance(value[1], (list, tuple)):
+            return [float(value[1])]  # type: ignore[arg-type]
+        return [list(item) if isinstance(item, (list, tuple)) else item for item in value]
+    return [value]
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    """Return the percentile using linear interpolation for small arrays."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (percentile / 100.0)
+    f = int(k)
+    c = min(f + 1, len(ordered) - 1)
+    if f == c:
+        return float(ordered[int(k)])
+    d0 = ordered[f] * (c - k)
+    d1 = ordered[c] * (k - f)
+    return float(d0 + d1)
+
+
+def _is_number(value: Any) -> bool:
+    """Safely determine whether a value is numeric."""
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return False

--- a/granite-test-generator/src/eval/metrics.py
+++ b/granite-test-generator/src/eval/metrics.py
@@ -1,0 +1,238 @@
+"""Reusable evaluation metrics for Granite SQE experiments."""
+
+from __future__ import annotations
+
+import logging
+import math
+from statistics import mean
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+try:  # pragma: no cover - torch optional in CI
+    import torch
+except Exception:  # pragma: no cover - fallback when torch unavailable
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import evaluate as hf_evaluate
+except Exception:  # pragma: no cover - evaluation optional
+    hf_evaluate = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+def compute_classification_metrics(
+    predictions: Iterable,
+    targets: Iterable,
+    probabilities: Optional[Iterable] = None,
+) -> Mapping[str, float]:
+    """Compute standard classification metrics with macro/micro variants."""
+    preds = _flatten_scalar(predictions)
+    gold = _flatten_scalar(targets)
+    if len(preds) != len(gold):
+        raise ValueError("Predictions and targets must share the same length")
+
+    labels = sorted(set(preds) | set(gold))
+    tp = {label: 0 for label in labels}
+    fp = {label: 0 for label in labels}
+    fn = {label: 0 for label in labels}
+
+    for pred, true in zip(preds, gold):
+        if pred == true:
+            tp[pred] += 1
+        else:
+            fp[pred] += 1
+            fn[true] += 1
+
+    precision_scores: List[float] = []
+    recall_scores: List[float] = []
+    f1_scores: List[float] = []
+    for label in labels:
+        tp_val = tp[label]
+        fp_val = fp[label]
+        fn_val = fn[label]
+        precision = tp_val / (tp_val + fp_val) if (tp_val + fp_val) else 0.0
+        recall = tp_val / (tp_val + fn_val) if (tp_val + fn_val) else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        precision_scores.append(precision)
+        recall_scores.append(recall)
+        f1_scores.append(f1)
+
+    accuracy = sum(1 for pred, true in zip(preds, gold) if pred == true) / max(len(gold), 1)
+    metrics: MutableMapping[str, float] = {
+        "accuracy": accuracy,
+        "precision_macro": mean(precision_scores) if precision_scores else 0.0,
+        "recall_macro": mean(recall_scores) if recall_scores else 0.0,
+        "f1_macro": mean(f1_scores) if f1_scores else 0.0,
+    }
+
+    tp_total = sum(tp.values())
+    fp_total = sum(fp.values())
+    fn_total = sum(fn.values())
+    precision_micro = tp_total / (tp_total + fp_total) if (tp_total + fp_total) else 0.0
+    recall_micro = tp_total / (tp_total + fn_total) if (tp_total + fn_total) else 0.0
+    f1_micro = (2 * precision_micro * recall_micro / (precision_micro + recall_micro)) if (precision_micro + recall_micro) else 0.0
+    metrics.update(
+        {
+            "precision_micro": precision_micro,
+            "recall_micro": recall_micro,
+            "f1_micro": f1_micro,
+        }
+    )
+
+    if probabilities is not None:
+        scores = _normalise_probabilities(probabilities, len(preds))
+        if scores:
+            metrics["auroc"] = _binary_auroc(gold, scores)
+    return metrics
+
+
+def compute_regression_metrics(predictions: Iterable, targets: Iterable) -> Mapping[str, float]:
+    """Compute MAE, RMSE, and R^2 regression metrics."""
+    preds = _flatten_float(predictions)
+    gold = _flatten_float(targets)
+    if len(preds) != len(gold):
+        raise ValueError("Predictions and targets must share the same length")
+
+    n = len(preds)
+    if n == 0:
+        return {"mae": 0.0, "rmse": 0.0, "r2": 0.0}
+
+    diffs = [p - g for p, g in zip(preds, gold)]
+    mae = sum(abs(d) for d in diffs) / n
+    rmse = math.sqrt(sum(d * d for d in diffs) / n)
+    mean_gold = sum(gold) / n
+    ss_res = sum((p - g) ** 2 for p, g in zip(preds, gold))
+    ss_tot = sum((g - mean_gold) ** 2 for g in gold)
+    r2 = 1.0 - ss_res / ss_tot if ss_tot else 1.0
+    return {"mae": mae, "rmse": rmse, "r2": r2}
+
+
+def compute_text_generation_metrics(
+    predictions: Sequence[str],
+    references: Sequence[Sequence[str]] | Sequence[str],
+    latencies_ms: Optional[Sequence[float]] = None,
+) -> Mapping[str, float]:
+    """Compute text generation metrics with optional HF evaluate integration."""
+    refs = [_normalise_references(ref) for ref in references]
+    metrics: MutableMapping[str, float] = {}
+
+    if hf_evaluate is not None:
+        try:
+            bleu = hf_evaluate.load("bleu")
+            rouge = hf_evaluate.load("rouge")
+            chrf = hf_evaluate.load("chrf")
+            metrics["bleu"] = float(bleu.compute(predictions=predictions, references=refs)["bleu"])
+            metrics["rouge_l"] = float(rouge.compute(predictions=predictions, references=refs)["rougeL"])
+            metrics["chrf"] = float(chrf.compute(predictions=predictions, references=refs)["score"])
+        except Exception as exc:  # pragma: no cover - network/cache issues
+            LOGGER.warning("Failed to compute advanced text metrics: %s", exc)
+
+    exact = []
+    for pred, ref_list in zip(predictions, refs):
+        exact.append(1.0 if pred.strip() in {ref.strip() for ref in ref_list} else 0.0)
+    metrics["exact_match"] = mean(exact) if exact else 0.0
+
+    if latencies_ms:
+        metrics["latency_ms_avg"] = mean(latencies_ms)
+        metrics["latency_ms_p95"] = _percentile(latencies_ms, 95)
+
+    return metrics
+
+
+def _flatten_scalar(values: Iterable) -> List[int]:
+    """Normalise arbitrary iterables of scalar-like values into integers."""
+    flattened: List[int] = []
+    for value in _iterate(values):
+        flattened.append(int(round(float(value))))
+    return flattened
+
+
+def _flatten_float(values: Iterable) -> List[float]:
+    """Normalise arbitrary iterables of scalar-like values into floats."""
+    return [float(item) for item in _iterate(values)]
+
+
+def _iterate(values: Iterable) -> List[float]:
+    """Return a flattened list representation for nested tensor-friendly inputs."""
+    if torch is not None and isinstance(values, torch.Tensor):
+        return values.detach().cpu().flatten().tolist()
+    if isinstance(values, (list, tuple)):
+        output: List[float] = []
+        for item in values:
+            output.extend(_iterate(item))
+        return output
+    return [float(values)]
+
+
+def _normalise_probabilities(probabilities: Iterable, expected_length: int) -> List[float]:
+    """Extract probability scores suitable for AUROC computation."""
+    scores: List[float] = []
+    for item in probabilities:
+        if torch is not None and isinstance(item, torch.Tensor):
+            normalised = item.detach().cpu().flatten().tolist()
+        elif isinstance(item, (list, tuple)):
+            normalised = list(item)
+        else:
+            normalised = [item]
+        if len(normalised) == 1:
+            scores.append(float(normalised[0]))
+        elif len(normalised) == 2:
+            scores.append(float(normalised[1]))
+        else:
+            LOGGER.debug("Skipping AUROC probability vector of length %s", len(normalised))
+    if len(scores) != expected_length:
+        LOGGER.debug("Probability count %s does not match expected %s", len(scores), expected_length)
+        return []
+    return scores
+
+
+def _binary_auroc(targets: List[int], scores: List[float]) -> float:
+    """Compute AUROC for binary classification without external dependencies."""
+    if len(set(targets)) < 2:
+        LOGGER.debug("AUROC undefined for single-class targets")
+        return float("nan")
+    positive_label = max(targets)
+    pairs = sorted(zip(scores, targets), key=lambda x: x[0])
+    pos_total = sum(1 for target in targets if target == positive_label)
+    neg_total = len(targets) - pos_total
+    if pos_total == 0 or neg_total == 0:
+        LOGGER.debug("AUROC undefined due to missing positive or negative samples")
+        return float("nan")
+
+    tpr = [0.0]
+    fpr = [0.0]
+    tp = fp = 0
+    for score, label in reversed(pairs):
+        if label == positive_label:
+            tp += 1
+        else:
+            fp += 1
+        tpr.append(tp / pos_total)
+        fpr.append(fp / neg_total)
+
+    auc = 0.0
+    for i in range(1, len(tpr)):
+        auc += (fpr[i] - fpr[i - 1]) * (tpr[i] + tpr[i - 1]) / 2.0
+    return auc
+
+
+def _normalise_references(ref: Sequence[str] | str) -> List[str]:
+    """Ensure text-generation references are represented as simple string lists."""
+    if isinstance(ref, str):
+        return [ref]
+    return [str(item) for item in ref]
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    """Compute the percentile using linear interpolation for small samples."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (percentile / 100.0)
+    f = math.floor(k)
+    c = min(f + 1, len(ordered) - 1)
+    if f == c:
+        return float(ordered[int(k)])
+    d0 = ordered[f] * (c - k)
+    d1 = ordered[c] * (k - f)
+    return float(d0 + d1)

--- a/granite-test-generator/src/models/granite_moe.py
+++ b/granite-test-generator/src/models/granite_moe.py
@@ -64,9 +64,12 @@ except Exception:  # pragma: no cover
     DataCollatorForLanguageModeling = _MissingDataCollatorForLanguageModeling  # type: ignore
     Dataset = _MissingDataset  # type: ignore
 import torch
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import List, Dict, Any, TYPE_CHECKING, Optional
+import os
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 # Optional MLX for Apple-silicon; fall back to template gen if missing
 try:
     import mlx.core as mx  # type: ignore
@@ -83,6 +86,7 @@ except Exception:  # pragma: no cover
 
 if TYPE_CHECKING:
     from src.models.test_case_schemas import TestCase, TestStep
+    from src.config.telemetry import TelemetryConfig
 
 class GraniteMoETrainer:
     def __init__(self, model_name: str = "ibm-granite/granite-3.0-1b-a400m-instruct"):
@@ -182,8 +186,15 @@ Create a test case for the above requirements.
 
         return prompt
     
-    def fine_tune(self, dataset: Dataset, output_dir: str = "./fine_tuned_granite",
-                  num_epochs: int = 3, batch_size: int = 4):
+    def fine_tune(
+        self,
+        dataset: Dataset,
+        output_dir: str = "./fine_tuned_granite",
+        num_epochs: int = 3,
+        batch_size: int = 4,
+        telemetry: Optional["TelemetryConfig"] = None,
+        log_checkpoints: bool = False,
+    ):
         """Fine-tune the model with QLoRA for memory efficiency"""
         from peft import LoraConfig, get_peft_model, TaskType
         
@@ -203,6 +214,21 @@ Create a test case for the above requirements.
             
         self.model = get_peft_model(self.model, lora_config)
         
+        report_to: List[str] = []
+        logging_dir = None
+        logging_steps = 10
+        if telemetry is not None:
+            logging_steps = telemetry.log_interval_steps
+            if telemetry.enable_wandb:
+                report_to.append("wandb")
+                if telemetry.wandb_project:
+                    os.environ.setdefault("WANDB_PROJECT", telemetry.wandb_project)
+                if telemetry.wandb_entity:
+                    os.environ.setdefault("WANDB_ENTITY", telemetry.wandb_entity)
+            if telemetry.enable_tensorboard:
+                report_to.append("tensorboard")
+                logging_dir = telemetry.tb_log_dir
+
         # Training arguments optimized for MacMini
         training_args = TrainingArguments(
             output_dir=output_dir,
@@ -210,7 +236,7 @@ Create a test case for the above requirements.
             per_device_train_batch_size=batch_size,
             gradient_accumulation_steps=4,
             warmup_steps=100,
-            logging_steps=10,
+            logging_steps=logging_steps,
             save_steps=500,
             evaluation_strategy="steps",
             eval_steps=500,
@@ -218,7 +244,8 @@ Create a test case for the above requirements.
             fp16=True,  # Mixed precision for memory efficiency
             dataloader_num_workers=0,  # Disable multiprocessing on Mac
             remove_unused_columns=False,
-            report_to=None  # Disable wandb for simplicity
+            report_to=report_to or None,
+            logging_dir=logging_dir,
         )
         
         # Data collator
@@ -236,11 +263,14 @@ Create a test case for the above requirements.
             data_collator=data_collator,
             tokenizer=self.tokenizer
         )
-        
+
         # Start training
         trainer.train()
         trainer.save_model()
-        
+
+        if not log_checkpoints:
+            logger.info("Checkpoint logging disabled; model saved locally but not uploaded to telemetry stores.")
+
         return trainer
 
     def prepare_offline_fine_tuning(self, dataset: Dataset, output_dir: str = "./fine_tuned_granite") -> tuple[str, str]:

--- a/granite-test-generator/src/telemetry/__init__.py
+++ b/granite-test-generator/src/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Experiment telemetry utilities."""
+
+from .experiment import ExperimentLogger
+
+__all__ = ["ExperimentLogger"]

--- a/granite-test-generator/src/telemetry/experiment.py
+++ b/granite-test-generator/src/telemetry/experiment.py
@@ -1,0 +1,251 @@
+"""Unified experiment logging for W&B and TensorBoard."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from contextlib import AbstractContextManager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from src.config.telemetry import TelemetryConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ExperimentLogger(AbstractContextManager["ExperimentLogger"]):
+    """Coordinate Weights & Biases and TensorBoard logging with graceful degradation."""
+
+    def __init__(
+        self,
+        telemetry_cfg: TelemetryConfig,
+        config_snapshot: Mapping[str, Any],
+        run_name: Optional[str] = None,
+    ) -> None:
+        self._cfg = telemetry_cfg
+        self._config_snapshot = dict(config_snapshot)
+        self._run_name = run_name
+        self._wandb_run: Optional[Any] = None
+        self._tb_writer: Optional[Any] = None
+        self._start_time: Optional[float] = None
+        self._git_sha: Optional[str] = None
+        self._closed = False
+
+    def __enter__(self) -> "ExperimentLogger":
+        self.start_run()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.finish()
+
+    def start_run(self) -> None:
+        if self._start_time is not None:
+            return
+        self._start_time = time.time()
+        self._run_name = self._run_name or self._derive_run_name()
+        self._git_sha = self._detect_git_sha()
+        LOGGER.debug("Starting experiment run: %s", self._run_name)
+
+        if self._cfg.enable_wandb:
+            self._start_wandb_run()
+        else:
+            LOGGER.debug("W&B telemetry disabled by configuration")
+
+        if self._cfg.enable_tensorboard:
+            self._start_tensorboard_writer()
+        else:
+            LOGGER.debug("TensorBoard telemetry disabled by configuration")
+
+        if self._config_snapshot:
+            self.log_params(**self._config_snapshot)
+
+    def log_metrics(self, step: int, **metrics: float) -> None:
+        if not metrics:
+            return
+        filtered = {k: float(v) for k, v in metrics.items() if self._is_number(v)}
+        if not filtered:
+            return
+        LOGGER.debug("Logging metrics at step %s: %s", step, filtered)
+
+        if self._wandb_run is not None:
+            payload = dict(filtered)
+            payload["step"] = step
+            try:
+                self._wandb_run.log(payload)
+            except Exception as exc:  # pragma: no cover - defensive safety
+                LOGGER.warning("Failed to log metrics to W&B: %s", exc)
+
+        if self._tb_writer is not None:
+            for key, value in filtered.items():
+                try:
+                    self._tb_writer.add_scalar(key, value, step)
+                except Exception as exc:  # pragma: no cover - defensive safety
+                    LOGGER.warning("Failed to write TensorBoard metric %s: %s", key, exc)
+            self._tb_writer.flush()
+
+    def log_params(self, **params: Any) -> None:
+        if not params:
+            return
+        LOGGER.debug("Logging parameters: %s", params)
+        if self._wandb_run is not None:
+            try:
+                config = getattr(self._wandb_run, "config", None)
+                if config is not None:
+                    config.update(params, allow_val_change=True)
+            except Exception as exc:  # pragma: no cover - defensive safety
+                LOGGER.warning("Failed to update W&B config: %s", exc)
+
+        if self._tb_writer is not None:
+            try:
+                self._tb_writer.add_text("hyperparameters", json.dumps(params, indent=2))
+            except Exception as exc:  # pragma: no cover - defensive safety
+                LOGGER.warning("Failed to write TensorBoard params: %s", exc)
+
+    def log_artifact(self, path: Any, name: Optional[str] = None, type: str = "artifact") -> None:
+        file_path = Path(path)
+        if not file_path.exists():
+            LOGGER.warning("Artifact path %s does not exist; skipping upload", file_path)
+            return
+
+        if self._wandb_run is not None:
+            try:
+                import wandb  # type: ignore
+
+                artifact = wandb.Artifact(name=name or file_path.name, type=type)
+                artifact.add_file(str(file_path))
+                self._wandb_run.log_artifact(artifact)
+                LOGGER.info("Logged artifact %s to W&B", file_path)
+            except Exception as exc:  # pragma: no cover - defensive safety
+                LOGGER.warning("Failed to log artifact to W&B: %s", exc)
+
+    def set_summary(self, **values: Any) -> None:
+        if not values:
+            return
+        LOGGER.debug("Updating summary metrics: %s", values)
+        if self._wandb_run is not None:
+            summary = getattr(self._wandb_run, "summary", None)
+            if summary is not None:
+                try:
+                    for key, value in values.items():
+                        summary[key] = value
+                except Exception as exc:  # pragma: no cover
+                    LOGGER.warning("Failed to update W&B summary: %s", exc)
+
+        if self._tb_writer is not None:
+            try:
+                self._tb_writer.add_text("summary", json.dumps(values, indent=2))
+            except Exception as exc:  # pragma: no cover
+                LOGGER.warning("Failed to write TensorBoard summary: %s", exc)
+
+    def finish(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._tb_writer is not None:
+            try:
+                self._tb_writer.flush()
+                self._tb_writer.close()
+            except Exception as exc:  # pragma: no cover
+                LOGGER.warning("Failed to close TensorBoard writer: %s", exc)
+            self._tb_writer = None
+        if self._wandb_run is not None:
+            try:
+                self._wandb_run.finish()
+            except Exception as exc:  # pragma: no cover
+                LOGGER.warning("Failed to close W&B run: %s", exc)
+            self._wandb_run = None
+        LOGGER.debug("Experiment logger finished")
+
+    def _start_wandb_run(self) -> None:
+        project = self._cfg.wandb_project or os.getenv("WANDB_PROJECT")
+        if not project:
+            LOGGER.warning("W&B enabled but no project provided; disabling W&B logging")
+            return
+
+        try:
+            import wandb  # type: ignore
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("W&B library unavailable: %s", exc)
+            return
+
+        entity = self._cfg.wandb_entity or os.getenv("WANDB_ENTITY")
+        run_name = self._cfg.wandb_run_name or self._run_name
+        tags = list(dict.fromkeys(self._cfg.wandb_tags))
+        if self._git_sha:
+            tags.append(self._git_sha)
+        tags = [tag for tag in tags if tag]
+
+        os.environ.setdefault("WANDB_PROJECT", project)
+        if entity:
+            os.environ.setdefault("WANDB_ENTITY", entity)
+        if run_name:
+            os.environ.setdefault("WANDB_RUN_NAME", run_name)
+        if tags:
+            os.environ["WANDB_TAGS"] = ",".join(tags)
+
+        settings = {"start_method": "thread"}
+        wandb_mode = os.getenv("WANDB_MODE")
+        if wandb_mode:
+            LOGGER.info("W&B mode=%s", wandb_mode)
+
+        try:
+            self._wandb_run = wandb.init(
+                project=project,
+                entity=entity,
+                name=run_name,
+                tags=tags or None,
+                config=dict(self._config_snapshot),
+                reinit=True,
+                settings=settings,
+            )
+            LOGGER.info("Initialized W&B run %s", self._wandb_run.name if self._wandb_run else run_name)
+            if self._git_sha and self._wandb_run is not None:
+                self._wandb_run.config.update({"git_sha": self._git_sha}, allow_val_change=True)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Failed to initialise W&B run: %s", exc)
+            self._wandb_run = None
+
+    def _start_tensorboard_writer(self) -> None:
+        try:
+            from torch.utils.tensorboard import SummaryWriter
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("TensorBoard SummaryWriter unavailable: %s", exc)
+            return
+
+        log_dir = Path(self._cfg.tb_log_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._tb_writer = SummaryWriter(log_dir=str(log_dir))
+            LOGGER.info("TensorBoard writer initialised at %s", log_dir)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Failed to create TensorBoard writer: %s", exc)
+            self._tb_writer = None
+
+    def _derive_run_name(self) -> str:
+        model_name = self._config_snapshot.get("model", {}).get("type") or self._config_snapshot.get("model_name", "model")
+        dataset_name = self._config_snapshot.get("data", {}).get("train_file") or self._config_snapshot.get("dataset", "dataset")
+        timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        safe_model = str(model_name).split("/")[-1]
+        safe_dataset = Path(str(dataset_name)).stem or "dataset"
+        return f"{safe_model}-{safe_dataset}-{timestamp}"
+
+    @staticmethod
+    def _detect_git_sha() -> Optional[str]:
+        try:
+            import subprocess
+
+            sha = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
+            return sha.decode().strip()
+        except Exception:  # pragma: no cover
+            return None
+
+    @staticmethod
+    def _is_number(value: Any) -> bool:
+        try:
+            float(value)
+            return True
+        except (TypeError, ValueError):
+            return False

--- a/scripts/tensorboard.sh
+++ b/scripts/tensorboard.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tensorboard --logdir "${TB_LOG_DIR:-runs}" --port "${TB_PORT:-6006}" --host 0.0.0.0

--- a/tests/integration/test_training_telemetry.py
+++ b/tests/integration/test_training_telemetry.py
@@ -1,0 +1,118 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("torch")
+pytest.importorskip("dotenv")
+
+from train import run_training
+
+
+class _IntegrationRun:
+    def __init__(self):
+        self.logged = []
+        self.artifacts = []
+        self.summary = {}
+        self.config = {}
+        self.name = "integration"
+
+    def log(self, payload):
+        self.logged.append(payload)
+
+    def log_artifact(self, artifact):
+        self.artifacts.append(artifact.name)
+
+    def finish(self):
+        pass
+
+
+class _IntegrationArtifact:
+    def __init__(self, name: str, type: str):
+        self.name = name
+        self.type = type
+        self._files = []
+
+    def add_file(self, path: str):
+        self._files.append(path)
+
+
+created_writers = []
+
+
+class _IntegrationWriter:
+    def __init__(self, log_dir: str):
+        self.log_dir = log_dir
+        self.scalars = []
+        created_writers.append(self)
+
+    def add_scalar(self, key: str, value: float, step: int):
+        self.scalars.append((key, value, step))
+
+    def add_text(self, key: str, value: str):
+        pass
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def stub_wandb(monkeypatch):
+    run = _IntegrationRun()
+    module = types.SimpleNamespace(init=lambda **kwargs: run, Artifact=_IntegrationArtifact)
+    monkeypatch.setitem(sys.modules, "wandb", module)
+    return run
+
+
+@pytest.fixture
+def stub_summary_writer(monkeypatch):
+    from torch.utils import tensorboard
+
+    monkeypatch.setattr(tensorboard, "SummaryWriter", _IntegrationWriter)
+    return _IntegrationWriter
+
+
+def test_training_generates_eval_report(tmp_path):
+    out_dir = tmp_path / "baseline"
+    run_training([
+        "--output-dir", str(out_dir),
+        "--task-type", "classification",
+        "--epochs", "1",
+        "--batch-size", "4",
+    ])
+    report_path = out_dir / "eval" / "eval_report.json"
+    assert report_path.exists()
+    data = report_path.read_text()
+    assert "accuracy" in data
+    assert "checkpoint_path" not in result.metrics
+
+
+def test_training_with_telemetry(stub_wandb, stub_summary_writer, tmp_path, monkeypatch):
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    out_dir = tmp_path / "telemetry"
+    tb_dir = tmp_path / "tb"
+
+    run_training([
+        "--output-dir", str(out_dir),
+        "--task-type", "classification",
+        "--epochs", "1",
+        "--batch-size", "4",
+        "--enable-wandb",
+        "--wandb-project", "integration-tests",
+        "--enable-tensorboard",
+        "--tb-log-dir", str(tb_dir),
+        "--log-checkpoints",
+    ])
+
+    assert stub_wandb.logged
+    assert "training-checkpoint" in stub_wandb.artifacts
+    checkpoint = out_dir / "checkpoints" / "model.pt"
+    assert checkpoint.exists()
+    report_path = out_dir / "eval" / "eval_report.json"
+    assert report_path.exists()
+    assert created_writers and created_writers[0].scalars

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,41 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.eval.metrics import (
+    compute_classification_metrics,
+    compute_regression_metrics,
+    compute_text_generation_metrics,
+)
+
+
+def test_classification_metrics():
+    preds = [0, 1, 1, 0]
+    targets = [0, 1, 0, 0]
+    probabilities = [0.2, 0.8, 0.6, 0.4]
+
+    metrics = compute_classification_metrics(preds, targets, probabilities)
+    assert math.isclose(metrics["accuracy"], 0.75)
+    assert "precision_macro" in metrics
+    assert "f1_micro" in metrics
+
+
+def test_regression_metrics():
+    preds = [2.0, 3.5, 4.0]
+    targets = [2.0, 3.0, 5.0]
+
+    metrics = compute_regression_metrics(preds, targets)
+    assert math.isclose(metrics["mae"], 0.5)
+    assert metrics["r2"] <= 1.0
+
+
+def test_text_generation_metrics():
+    preds = ["hello world", "lorem ipsum"]
+    refs = [["hello world"], ["dolor sit"]]
+    latencies = [10.0, 12.0]
+
+    metrics = compute_text_generation_metrics(preds, refs, latencies_ms=latencies)
+    assert math.isclose(metrics["exact_match"], 0.5)
+    assert "latency_ms_avg" in metrics

--- a/tests/test_telemetry_noop.py
+++ b/tests/test_telemetry_noop.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.config import TelemetryConfig
+from src.telemetry import ExperimentLogger
+
+
+def test_experiment_logger_noop(tmp_path, caplog):
+    caplog.set_level(logging.DEBUG)
+    cfg = TelemetryConfig()
+    snapshot = {"model": {"type": "noop"}}
+
+    with ExperimentLogger(cfg, snapshot) as logger:
+        logger.log_metrics(1, loss=0.01)
+        logger.log_params(learning_rate=1e-3)
+        logger.set_summary(final_loss=0.01)
+        logger.log_artifact(tmp_path / "missing.txt")
+
+    runs_dir = Path("runs")
+    assert not runs_dir.exists() or not any(runs_dir.iterdir())

--- a/tests/test_telemetry_wandb_tb.py
+++ b/tests/test_telemetry_wandb_tb.py
@@ -1,0 +1,114 @@
+import sys
+import types
+from typing import Any
+
+import pytest
+from pathlib import Path
+
+pytest.importorskip("pydantic")
+pytest.importorskip("torch")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.config import TelemetryConfig
+from src.telemetry import ExperimentLogger
+
+
+class DummyConfig(dict):
+    def update(self, other: Any, allow_val_change: bool = True):
+        super().update(other)
+
+
+class DummyRun:
+    def __init__(self):
+        self.logged = []
+        self.artifacts = []
+        self.summary = {}
+        self.config = DummyConfig()
+        self.name = "dummy"
+
+    def log(self, payload):
+        self.logged.append(payload)
+
+    def log_artifact(self, artifact):
+        self.artifacts.append(artifact.name)
+
+    def finish(self):
+        pass
+
+
+class DummyArtifact:
+    def __init__(self, name: str, type: str):
+        self.name = name
+        self.type = type
+        self.files = []
+
+    def add_file(self, path: str):
+        self.files.append(path)
+
+
+created_writers = []
+
+
+class DummySummaryWriter:
+    def __init__(self, log_dir: str):
+        self.log_dir = log_dir
+        self.scalars = []
+        self.texts = []
+        created_writers.append(self)
+
+    def add_scalar(self, key: str, value: float, step: int):
+        self.scalars.append((key, value, step))
+
+    def add_text(self, key: str, text: str):
+        self.texts.append((key, text))
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch):
+    run = DummyRun()
+    module = types.SimpleNamespace(
+        init=lambda **kwargs: run,
+        Artifact=DummyArtifact,
+    )
+    monkeypatch.setitem(sys.modules, "wandb", module)
+    return run
+
+
+@pytest.fixture
+def fake_summary_writer(monkeypatch, tmp_path):
+    from torch.utils import tensorboard
+
+    monkeypatch.setattr(tensorboard, "SummaryWriter", DummySummaryWriter)
+    return tmp_path
+
+
+def test_experiment_logger_full_stack(fake_wandb, fake_summary_writer, tmp_path, monkeypatch):
+    cfg = TelemetryConfig(
+        enable_wandb=True,
+        wandb_project="granite-tests",
+        enable_tensorboard=True,
+        tb_log_dir=str(fake_summary_writer / "logs"),
+        wandb_tags=["unit"],
+    )
+    snapshot = {"model": {"type": "demo"}}
+
+    artifact_path = tmp_path / "artifact.txt"
+    artifact_path.write_text("demo")
+
+    with ExperimentLogger(cfg, snapshot) as logger:
+        logger.log_metrics(1, loss=0.5)
+        logger.log_params(batch_size=4)
+        logger.log_artifact(artifact_path, name="artifact")
+        logger.set_summary(final_loss=0.5)
+
+    assert fake_wandb.logged
+    assert "artifact" in fake_wandb.artifacts
+    assert created_writers
+    assert any(entry[0] == "loss" for entry in created_writers[0].scalars)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,300 @@
+"""Lightweight training harness with telemetry instrumentation."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from dotenv import load_dotenv
+
+try:  # pragma: no cover - torch optional in some environments
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+except Exception:  # pragma: no cover - graceful fallback
+    torch = None  # type: ignore
+    nn = None  # type: ignore
+    DataLoader = None  # type: ignore
+    TensorDataset = None  # type: ignore
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml should be available
+    yaml = None  # type: ignore
+
+from src.config import load_telemetry_from_sources
+from src.telemetry import ExperimentLogger
+from src.eval.evaluate import evaluate
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_CONFIG_PATH = Path("config/training_config.yaml")
+
+
+@dataclass
+class TrainingArtifacts:
+    """Bundle of resources produced by the training loop."""
+
+    model: Any
+    metrics: Dict[str, float]
+    checkpoint_path: Optional[Path]
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Granite SQE training harness")
+    parser.add_argument("--config", type=str, default=str(DEFAULT_CONFIG_PATH), help="Path to training configuration YAML")
+    parser.add_argument("--task-type", choices=["classification", "regression", "text"], default="classification")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--output-dir", type=str, default="artifacts/training")
+    parser.add_argument("--device", type=str, default=None, help="Target device override (cpu/cuda)")
+    parser.add_argument("--log-checkpoints", action="store_true", help="Upload model checkpoints via telemetry backends")
+    parser.add_argument("--log-interval-steps", type=int, default=None, help="Override telemetry logging interval")
+
+    # Telemetry toggles
+    parser.add_argument("--enable-wandb", dest="enable_wandb", action="store_true", help="Enable W&B logging")
+    parser.add_argument("--disable-wandb", dest="enable_wandb", action="store_false", help="Disable W&B logging")
+    parser.set_defaults(enable_wandb=None)
+    parser.add_argument("--wandb-project", type=str, default=None)
+    parser.add_argument("--wandb-entity", type=str, default=None)
+    parser.add_argument("--wandb-run-name", type=str, default=None)
+    parser.add_argument("--wandb-tags", type=str, default=None, help="Comma separated list of W&B tags")
+
+    parser.add_argument("--enable-tensorboard", dest="enable_tensorboard", action="store_true", help="Enable TensorBoard logging")
+    parser.add_argument("--disable-tensorboard", dest="enable_tensorboard", action="store_false", help="Disable TensorBoard logging")
+    parser.set_defaults(enable_tensorboard=None)
+    parser.add_argument("--tb-log-dir", type=str, default=None, help="TensorBoard log directory")
+
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _load_training_config(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        LOGGER.warning("Training config %s not found; proceeding with defaults", path)
+        return {}
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load the training configuration")
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def _build_config_snapshot(args: argparse.Namespace, config: Dict[str, Any]) -> Dict[str, Any]:
+    snapshot = {
+        "model": config.get("model", {"type": "toy-net"}),
+        "training": {
+            "epochs": args.epochs,
+            "batch_size": args.batch_size,
+            "learning_rate": args.learning_rate,
+            "task_type": args.task_type,
+        },
+        "data": config.get("data", {"source": "synthetic"}),
+    }
+    return snapshot
+
+
+def _resolve_device(preferred: Optional[str]) -> str:
+    if torch is None:
+        return "cpu"
+    if preferred:
+        return preferred
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _prepare_classification_data(batch_size: int) -> Tuple[Iterable, Iterable, int]:
+    if torch is None or TensorDataset is None:
+        raise RuntimeError("PyTorch is required for classification training")
+    rng = torch.Generator().manual_seed(42)
+    features = torch.randn(128, 4, generator=rng)
+    labels = (features.sum(dim=1) > 0).long()
+    dataset = TensorDataset(features, labels)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, generator=rng)
+    eval_loader = DataLoader(dataset, batch_size=batch_size)
+    return loader, eval_loader, features.shape[1]
+
+
+def _prepare_regression_data(batch_size: int) -> Tuple[Iterable, Iterable, int]:
+    if torch is None or TensorDataset is None:
+        raise RuntimeError("PyTorch is required for regression training")
+    rng = torch.Generator().manual_seed(24)
+    features = torch.randn(128, 3, generator=rng)
+    weights = torch.tensor([0.6, -0.3, 0.9])
+    labels = features @ weights + 0.1
+    dataset = TensorDataset(features, labels.unsqueeze(-1))
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, generator=rng)
+    eval_loader = DataLoader(dataset, batch_size=batch_size)
+    return loader, eval_loader, features.shape[1]
+
+
+def _prepare_text_data() -> Tuple[Iterable, Iterable, int]:
+    samples = [
+        {"inputs": "Generate summary for login flow", "labels": "Login flow summary"},
+        {"inputs": "Document checkout process", "labels": "Checkout process document"},
+    ]
+    return samples, samples, 0
+
+
+class _ClassificationNet(nn.Module):
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(input_dim, 2)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.linear(features)
+
+
+class _RegressionNet(nn.Module):
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(input_dim, 1)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.linear(features)
+
+
+class _TextEchoModel:
+    def __call__(self, batch: Any) -> Any:
+        if isinstance(batch, str):
+            return batch
+        if isinstance(batch, Iterable):
+            return [str(item) for item in batch]
+        return str(batch)
+
+
+def _train_epoch(
+    model: nn.Module,
+    loader: Iterable,
+    optimizer: Any,
+    device: str,
+    task_type: str,
+) -> Dict[str, float]:
+    assert torch is not None
+    model.train()
+    total_loss = 0.0
+    total_correct = 0.0
+    total_examples = 0
+    criterion = nn.CrossEntropyLoss() if task_type == "classification" else nn.MSELoss()
+
+    for batch_inputs, batch_labels in loader:
+        batch_inputs = batch_inputs.to(device)
+        batch_labels = batch_labels.to(device)
+        optimizer.zero_grad()
+        outputs = model(batch_inputs)
+        if task_type == "classification":
+            loss = criterion(outputs, batch_labels)
+            preds = outputs.argmax(dim=1)
+            total_correct += float((preds == batch_labels).float().sum().item())
+            total_examples += batch_labels.shape[0]
+        else:
+            loss = criterion(outputs, batch_labels)
+            total_examples += batch_labels.shape[0]
+        loss.backward()
+        optimizer.step()
+        total_loss += float(loss.item()) * batch_labels.shape[0]
+
+    metrics = {
+        "loss": total_loss / max(total_examples, 1),
+    }
+    if task_type == "classification":
+        metrics["accuracy"] = total_correct / max(total_examples, 1)
+    return metrics
+
+
+def _save_checkpoint(model: nn.Module, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = output_dir / "model.pt"
+    torch.save(model.state_dict(), checkpoint_path)
+    return checkpoint_path
+
+
+def run_training(argv: Optional[Iterable[str]] = None) -> TrainingArtifacts:
+    load_dotenv()
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
+
+    config_path = Path(args.config)
+    config = _load_training_config(config_path)
+
+    telemetry_cfg = load_telemetry_from_sources(args)
+    if args.log_interval_steps is not None:
+        telemetry_cfg = telemetry_cfg.merged_with(log_interval_steps=args.log_interval_steps)
+
+    device = _resolve_device(args.device)
+    snapshot = _build_config_snapshot(args, config)
+    snapshot["runtime"] = {"device": device}
+
+    model: Any
+    train_loader: Iterable
+    eval_loader: Iterable
+    input_dim = 0
+
+    if args.task_type == "classification":
+        train_loader, eval_loader, input_dim = _prepare_classification_data(args.batch_size)
+        model = _ClassificationNet(input_dim)
+    elif args.task_type == "regression":
+        train_loader, eval_loader, input_dim = _prepare_regression_data(args.batch_size)
+        model = _RegressionNet(input_dim)
+    else:
+        train_loader, eval_loader, _ = _prepare_text_data()
+        model = _TextEchoModel()
+
+    if torch is not None and isinstance(model, nn.Module):
+        model.to(device)
+
+    optimizer = None
+    if torch is not None and isinstance(model, nn.Module):
+        optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
+
+    total_steps = 0
+    best_metric = None
+    best_metric_name = "accuracy" if args.task_type == "classification" else ("r2" if args.task_type == "regression" else "exact_match")
+
+    with ExperimentLogger(telemetry_cfg, snapshot) as experiment:
+        for epoch in range(1, args.epochs + 1):
+            if torch is not None and isinstance(model, nn.Module):
+                epoch_metrics = _train_epoch(model, train_loader, optimizer, device, args.task_type)
+                total_steps += len(train_loader)
+                experiment.log_metrics(total_steps, epoch=epoch, **epoch_metrics)
+            else:
+                LOGGER.info("Skipping parameterized training for task %s", args.task_type)
+
+            eval_dir = Path(args.output_dir) / "eval"
+            eval_metrics = evaluate(
+                model,
+                eval_loader,
+                task_type=args.task_type,
+                device=device,
+                experiment_logger=experiment,
+                output_dir=eval_dir,
+                epoch=epoch,
+            )
+            metric_value = eval_metrics.get(best_metric_name)
+            if metric_value is not None and (best_metric is None or metric_value > best_metric):
+                best_metric = metric_value
+
+        summary = {
+            "best_metric": best_metric if best_metric is not None else 0.0,
+            "best_metric_name": best_metric_name,
+            "epochs": args.epochs,
+            "total_steps": total_steps,
+        }
+        experiment.set_summary(**summary)
+
+        checkpoint_path = None
+        if args.log_checkpoints and torch is not None and isinstance(model, nn.Module):
+            checkpoint_dir = Path(args.output_dir) / "checkpoints"
+            checkpoint_path = _save_checkpoint(model, checkpoint_dir)
+            experiment.log_artifact(checkpoint_path, name="training-checkpoint", type="model")
+
+    metrics = summary if "summary" in locals() else {}
+    return TrainingArtifacts(model=model, metrics=metrics, checkpoint_path=checkpoint_path)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    run_training(argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a TelemetryConfig model and ExperimentLogger facade to enable optional W&B and TensorBoard logging with graceful fallbacks.【F:granite-test-generator/src/config/telemetry.py†L1-L143】【F:granite-test-generator/src/telemetry/experiment.py†L1-L251】
- add reusable evaluation helpers (metrics + evaluate) and wire the training harness to log metrics, summaries, and artifacts through the new telemetry layer.【F:granite-test-generator/src/eval/metrics.py†L1-L176】【F:granite-test-generator/src/eval/evaluate.py†L1-L129】【F:train.py†L212-L292】
- expose CLI/env controls, documentation, and tooling (Makefile, TensorBoard script, env sample) plus update the Granite HF trainer to respect telemetry settings.【F:train.py†L45-L205】【F:granite-test-generator/src/models/granite_moe.py†L189-L272】【F:README.md†L1-L82】【F:.env.sample†L1-L22】【F:scripts/tensorboard.sh†L1-L4】

## Testing
- `pytest tests/test_eval_metrics.py -q`【f5ec15†L1-L3】
- `pytest tests/test_telemetry_noop.py -q` *(skipped – requires pydantic in environment)*【9a73c8†L1-L3】
- `pytest tests/test_telemetry_wandb_tb.py -q` *(skipped – requires torch & pydantic)*【1a23e7†L1-L3】
- `pytest tests/integration/test_training_telemetry.py -q` *(skipped – requires torch & pydantic)*【d6a667†L1-L3】
- `pytest -q` *(fails: environment lacks pydantic/torch/requests dependencies for existing suites)*【ecc7ae†L1-L120】

------
https://chatgpt.com/codex/tasks/task_e_68d9b023edd08332bbfb185af156e6da