### PR TITLE
Improve OpenAI prompt token management

### DIFF
--- a/granite-test-generator/requirements.txt
+++ b/granite-test-generator/requirements.txt
@@ -101,6 +101,7 @@ notebook==7.4.7
 notebook_shim==0.2.4
 numpy==1.26.4
 oauthlib==3.3.1
+openai>=1.0.0
 onnxruntime==1.23.0
 opentelemetry-api==1.37.0
 opentelemetry-exporter-otlp-proto-common==1.37.0
@@ -162,6 +163,7 @@ tenacity==9.1.2
 terminado==0.18.1
 tinycss2==1.4.0
 tokenizers==0.22.1
+tiktoken>=0.7.0
 tomli==2.2.1
 torch==2.2.2
 torchaudio==2.2.2

--- a/granite-test-generator/src/agents/test_generation_agent.py
+++ b/granite-test-generator/src/agents/test_generation_agent.py
@@ -19,6 +19,7 @@ from typing import List, Dict, Any, Optional
 import asyncio
 from typing import TYPE_CHECKING
 from src.utils.constants import TEMPLATE_PATTERNS
+from src.integration.openai_client import OpenAIClient, OpenAIIntegrationError
 from src.models.test_case_schemas import (
     TestCase,
     TestStep,
@@ -55,6 +56,18 @@ class TestGenerationAgent:
         self._logger = logging.getLogger(__name__)
         # Disallow template/dummy generation unless explicitly enabled
         self._allow_template_generation = str(os.getenv("ALLOW_TEMPLATE_GENERATION", "false")).lower() in ("1", "true", "yes")
+
+        self._openai_client: Optional[OpenAIClient] = None
+        openai_key = os.getenv("OPENAI_API_KEY")
+        if openai_key:
+            try:
+                self._openai_client = OpenAIClient(api_key=openai_key)
+                self._logger.info(
+                    "OpenAI integration enabled for remote test case generation using model %s",
+                    self._openai_client.default_model,
+                )
+            except OpenAIIntegrationError as exc:
+                self._logger.warning("OpenAI integration disabled: %s", exc)
         
     def _initialize_tools(self) -> List[Tool]:
         """Initialize tools for the agent"""
@@ -96,14 +109,22 @@ class TestGenerationAgent:
     
     def _generate_test_case(self, requirement: str) -> str:
         """Generate test case using MLX model, transformers model, or fallback templating."""
+        prompt = self._build_generation_prompt(requirement)
+
+        if self._openai_client:
+            try:
+                return self._generate_with_openai(prompt)
+            except OpenAIIntegrationError as exc:
+                self._logger.warning("OpenAI generation failed, falling back to local models: %s", exc)
+
         # Try MLX first (optimal for Apple Silicon)
         if not getattr(self.granite_model, 'mlx_model', None) or not getattr(self.granite_model, 'mlx_tokenizer', None):
             self.granite_model.load_model_for_inference()
-        
+
         # If MLX not available, try transformers model
         if not getattr(self.granite_model, 'mlx_model', None):
-            return self._generate_with_transformers(requirement)
-        
+            return self._generate_with_transformers(requirement, prompt)
+
         # If no models available, only allow template generation when explicitly enabled
         if not getattr(self.granite_model, 'mlx_model', None) and not getattr(self.granite_model, 'model', None):
             if not getattr(self, '_allow_template_generation', False):
@@ -111,25 +132,6 @@ class TestGenerationAgent:
                     "No generation backend available (MLX/Transformers) and template generation is disabled."
                 )
             return self._template_generate(requirement)
-
-        prompt = f"""<|system|>
-You are an expert software quality engineer. Create a comprehensive, detailed test case that thoroughly validates the system against the given requirement. Include specific validation steps, edge cases, error conditions, and acceptance criteria verification.
-
-<|user|>
-Requirement: {requirement}
-
-Create a detailed test case that includes:
-1. A clear, specific summary describing what is being tested
-2. Comprehensive test steps with detailed actions and specific validation points
-3. Expected results that validate all acceptance criteria
-4. Input data requirements and test data specifications
-5. Verification of security, performance, and functional requirements
-6. Edge cases and error condition testing
-7. Specific assertions and validation checks
-
-Format your response with [TEST_CASE][SUMMARY]...[/SUMMARY][INPUT_DATA]...[/INPUT_DATA][STEPS]...[/STEPS][EXPECTED]...[/EXPECTED][/TEST_CASE]
-
-<|assistant|>"""
 
         try:
             response = generate(
@@ -152,24 +154,11 @@ Format your response with [TEST_CASE][SUMMARY]...[/SUMMARY][INPUT_DATA]...[/INPU
         except Exception:
             # Final fallback
             return self._template_generate(requirement)
-    
-    def _generate_with_transformers(self, requirement: str) -> str:
-        """Generate test case using transformers library when MLX is not available."""
-        
-        try:
-            # Load transformers model if not already loaded
-            if not getattr(self.granite_model, 'model', None):
-                self._logger.info("Loading transformers model for test case generation")
-                self.granite_model.load_model_for_training()
-            
-            if not getattr(self.granite_model, 'model', None):
-                if not getattr(self, '_allow_template_generation', False):
-                    raise RuntimeError("Transformers backend missing and template generation disabled")
-                self._logger.warning("Transformers model not available, falling back to template generation")
-                return self._template_generate(requirement)
-            
-            # Create enhanced prompt for transformers
-            prompt = f"""<|system|>
+
+    def _build_generation_prompt(self, requirement: str) -> str:
+        """Construct a detailed prompt for any generation backend."""
+
+        return f"""<|system|>
 You are an expert software quality engineer. Create a comprehensive, detailed test case that thoroughly validates the system against the given requirement. Include specific validation steps, edge cases, error conditions, and acceptance criteria verification.
 
 <|user|>
@@ -187,6 +176,36 @@ Create a detailed test case that includes:
 Format your response with [TEST_CASE][SUMMARY]...[/SUMMARY][INPUT_DATA]...[/INPUT_DATA][STEPS]...[/STEPS][EXPECTED]...[/EXPECTED][/TEST_CASE]
 
 <|assistant|>"""
+
+    def _generate_with_openai(self, prompt: str) -> str:
+        """Generate a test case via the OpenAI integration."""
+
+        if not self._openai_client:
+            raise OpenAIIntegrationError("OpenAI client not initialized")
+
+        return self._openai_client.generate_response(
+            prompt,
+            temperature=0.55,
+            max_output_tokens=900,
+        )
+
+    def _generate_with_transformers(self, requirement: str, prompt: Optional[str] = None) -> str:
+        """Generate test case using transformers library when MLX is not available."""
+
+        try:
+            # Load transformers model if not already loaded
+            if not getattr(self.granite_model, 'model', None):
+                self._logger.info("Loading transformers model for test case generation")
+                self.granite_model.load_model_for_training()
+
+            if not getattr(self.granite_model, 'model', None):
+                if not getattr(self, '_allow_template_generation', False):
+                    raise RuntimeError("Transformers backend missing and template generation disabled")
+                self._logger.warning("Transformers model not available, falling back to template generation")
+                return self._template_generate(requirement)
+
+            # Create enhanced prompt for transformers
+            prompt = prompt or self._build_generation_prompt(requirement)
 
             # Tokenize and generate
             inputs = self.granite_model.tokenizer(prompt, return_tensors="pt", truncation=True, max_length=2048)

--- a/granite-test-generator/src/agents/test_generation_agent.py
+++ b/granite-test-generator/src/agents/test_generation_agent.py
@@ -123,7 +123,7 @@ class TestGenerationAgent:
 
         # If MLX not available, try transformers model
         if not getattr(self.granite_model, 'mlx_model', None):
-            return self._generate_with_transformers(requirement, prompt)
+            return self._generate_with_transformers(requirement)
 
         # If no models available, only allow template generation when explicitly enabled
         if not getattr(self.granite_model, 'mlx_model', None) and not getattr(self.granite_model, 'model', None):

--- a/granite-test-generator/src/integration/openai_client.py
+++ b/granite-test-generator/src/integration/openai_client.py
@@ -187,7 +187,7 @@ class OpenAIClient:
         tail_tokens = min(len(tokens), max(0, base_budget // 3))
         head_tokens = max(0, base_budget - tail_tokens)
 
-        truncated_sequence: List[Union[int, str]] = []
+        truncated_sequence = []
         if head_tokens:
             truncated_sequence.extend(tokens[:head_tokens])
         truncated_sequence.extend(filler_tokens)
@@ -259,9 +259,14 @@ class OpenAIClient:
         elif isinstance(override, int) and override > 0:
             return override
 
-        for known_model, window in _MODEL_CONTEXT_WINDOWS.items():
-            if model_name and known_model in model_name:
-                return window
+        if model_name:
+            # First, try exact match
+            if model_name in _MODEL_CONTEXT_WINDOWS:
+                return _MODEL_CONTEXT_WINDOWS[model_name]
+            # Optionally, try safe prefix match (e.g., "gpt-4.1" should match "gpt-4.1-xxx")
+            for known_model, window in _MODEL_CONTEXT_WINDOWS.items():
+                if model_name.startswith(known_model + "-") or model_name.startswith(known_model + "."):
+                    return window
 
         return DEFAULT_CONTEXT_TOKEN_LIMIT
 

--- a/granite-test-generator/src/integration/openai_client.py
+++ b/granite-test-generator/src/integration/openai_client.py
@@ -1,0 +1,276 @@
+"""Utility client for interacting with OpenAI models via the Responses API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from importlib import util as importlib_util
+from typing import Optional, Tuple, List, Union
+
+
+logger = logging.getLogger(__name__)
+
+_OPENAI_AVAILABLE = importlib_util.find_spec("openai") is not None
+_TIKTOKEN_AVAILABLE = importlib_util.find_spec("tiktoken") is not None
+
+if _OPENAI_AVAILABLE:  # pragma: no cover - exercised only when dependency installed
+    from openai import OpenAI  # type: ignore
+else:  # pragma: no cover - handled gracefully by OpenAIClient
+    OpenAI = None  # type: ignore
+
+if _TIKTOKEN_AVAILABLE:  # pragma: no cover - optional dependency for token accounting
+    import tiktoken  # type: ignore
+else:  # pragma: no cover - handled gracefully via fallbacks
+    tiktoken = None  # type: ignore
+
+
+DEFAULT_CONTEXT_TOKEN_LIMIT = 128_000
+
+# Best-effort context window sizes for common OpenAI models. Values represent the
+# total token budget (prompt + completion) supported by the model.
+_MODEL_CONTEXT_WINDOWS = {
+    "gpt-4o-mini": 128_000,
+    "gpt-4o": 128_000,
+    "gpt-4.1": 128_000,
+    "gpt-4.1-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4.1-preview": 128_000,
+    "gpt-4.1-nano": 128_000,
+    "gpt-3.5-turbo": 16_385,
+}
+
+# Notice inserted into prompts when truncation is required to stay within the
+# model's context window. The message helps downstream debugging by signalling
+# that some context was dropped before calling the OpenAI API.
+_TRUNCATION_NOTICE = "\n\n[TRUNCATED: content shortened to fit token budget]\n\n"
+
+
+class OpenAIIntegrationError(RuntimeError):
+    """Raised when an OpenAI integration issue prevents a request."""
+
+
+class OpenAIClient:
+    """Lightweight wrapper around the OpenAI Python SDK."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        default_model: str = "gpt-4o-mini",
+        max_context_tokens: Optional[int] = None,
+    ) -> None:
+        if not _OPENAI_AVAILABLE:
+            raise OpenAIIntegrationError("The 'openai' package is not installed in this environment.")
+
+        resolved_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not resolved_key:
+            raise OpenAIIntegrationError("OpenAI API key is not configured. Set OPENAI_API_KEY to enable the integration.")
+
+        self._client = OpenAI(api_key=resolved_key)
+        self.default_model = os.getenv("OPENAI_MODEL", default_model)
+        self.max_context_tokens = self._resolve_context_window(
+            self.default_model,
+            override=max_context_tokens or os.getenv("OPENAI_CONTEXT_WINDOW"),
+        )
+
+        safe_model = self.default_model or "<unspecified>"
+        logger.debug("OpenAIClient initialized for model %s", safe_model)
+
+    def generate_response(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        temperature: float = 0.6,
+        max_output_tokens: int = 600,
+    ) -> str:
+        """Generate a response for the supplied prompt using OpenAI Responses API."""
+
+        target_model = model or self.default_model
+        if not target_model:
+            raise OpenAIIntegrationError("No OpenAI model specified. Provide OPENAI_MODEL or pass model explicitly.")
+
+        prompt, max_output_tokens = self._optimise_prompt_budget(
+            prompt,
+            target_model,
+            max_output_tokens,
+        )
+
+        try:
+            response = self._client.responses.create(
+                model=target_model,
+                input=prompt,
+                temperature=temperature,
+                max_output_tokens=max_output_tokens,
+            )
+        except Exception as exc:  # pragma: no cover - network errors are environment specific
+            raise OpenAIIntegrationError(
+                f"Failed to generate response with OpenAI model '{target_model}': {exc}"
+            ) from exc
+
+        output_text = getattr(response, "output_text", None)
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text
+
+        # Fall back to assembling text manually for SDK versions without output_text helper.
+        output_chunks = getattr(response, "output", None)
+        if not output_chunks:
+            raise OpenAIIntegrationError("OpenAI response did not include any text output.")
+
+        segments: list[str] = []
+        for chunk in output_chunks:
+            for content in getattr(chunk, "content", []) or []:
+                text = getattr(content, "text", None)
+                if isinstance(text, str):
+                    segments.append(text)
+
+        if not segments:
+            raise OpenAIIntegrationError("OpenAI response contained no textual content.")
+
+        return "".join(segments)
+
+    def count_tokens(self, text: str, model: Optional[str] = None) -> int:
+        """Estimate the number of tokens for *text* under the requested model.
+
+        When the optional :mod:`tiktoken` dependency is available the calculation
+        is exact for supported models. Otherwise, a character-level approximation
+        is used which still enables budget management without additional
+        dependencies.
+        """
+
+        tokens, _ = self._encode_text(text, model)
+        return len(tokens)
+
+    def _optimise_prompt_budget(
+        self,
+        prompt: str,
+        model: Optional[str],
+        max_output_tokens: int,
+    ) -> Tuple[str, int]:
+        """Ensure the prompt and requested output fit within the model budget."""
+
+        tokens, encoding = self._encode_text(prompt, model)
+        input_tokens = len(tokens)
+        if input_tokens + max_output_tokens <= self.max_context_tokens:
+            return prompt, max_output_tokens
+
+        allowed_input_tokens = max(self.max_context_tokens - max_output_tokens, 0)
+        logger.info(
+            "Prompt length %s tokens exceeds %s-token context window; reserving %s tokens for completion",
+            input_tokens,
+            self.max_context_tokens,
+            max_output_tokens,
+        )
+
+        if allowed_input_tokens <= 0:
+            truncated_tokens = tokens[: self.max_context_tokens]
+            truncated_prompt = self._decode_tokens(truncated_tokens, encoding)
+            logger.warning(
+                "OpenAI prompt truncated to %s tokens leaving minimal room for completion; consider reducing prompt size",
+                len(truncated_tokens),
+            )
+            return truncated_prompt, max(1, self.max_context_tokens - len(truncated_tokens))
+
+        filler_tokens, _ = self._encode_text(_TRUNCATION_NOTICE, model, encoding)
+        filler_len = len(filler_tokens)
+
+        if allowed_input_tokens <= filler_len + 1:
+            truncated_tokens = tokens[-allowed_input_tokens:]
+            truncated_prompt = self._decode_tokens(truncated_tokens, encoding)
+            logger.warning(
+                "Prompt severely truncated to last %s tokens to satisfy context window.",
+                len(truncated_tokens),
+            )
+            return truncated_prompt, max(1, self.max_context_tokens - len(truncated_tokens))
+
+        base_budget = allowed_input_tokens - filler_len
+        tail_tokens = min(len(tokens), max(0, base_budget // 3))
+        head_tokens = max(0, base_budget - tail_tokens)
+
+        truncated_sequence: List[Union[int, str]] = []
+        if head_tokens:
+            truncated_sequence.extend(tokens[:head_tokens])
+        truncated_sequence.extend(filler_tokens)
+        if tail_tokens:
+            truncated_sequence.extend(tokens[-tail_tokens:])
+
+        truncated_prompt = self._decode_tokens(truncated_sequence, encoding)
+        input_budget = len(truncated_sequence)
+        completion_budget = max(1, min(max_output_tokens, self.max_context_tokens - input_budget))
+
+        logger.info(
+            "Trimmed OpenAI prompt from %s to %s tokens; reserving %s tokens for completion.",
+            input_tokens,
+            input_budget,
+            completion_budget,
+        )
+
+        return truncated_prompt, completion_budget
+
+    def _encode_text(
+        self,
+        text: str,
+        model: Optional[str],
+        encoding=None,
+    ) -> Tuple[List[Union[int, str]], Optional[object]]:
+        """Encode *text* into token identifiers for the supplied model."""
+
+        if encoding is None:
+            encoding = self._get_encoding_for_model(model or self.default_model)
+
+        if encoding is not None:
+            return encoding.encode(text), encoding
+
+        # Character-level fallback keeps behaviour deterministic even when the
+        # optional tiktoken dependency is not installed.
+        return list(text), None
+
+    def _decode_tokens(
+        self,
+        tokens: List[Union[int, str]],
+        encoding,
+    ) -> str:
+        if encoding is not None:
+            return encoding.decode(tokens)
+        return "".join(tokens)
+
+    @staticmethod
+    @lru_cache(maxsize=16)
+    def _get_encoding_for_model(model_name: Optional[str]):
+        if not model_name or not _TIKTOKEN_AVAILABLE or tiktoken is None:
+            return None
+
+        try:
+            return tiktoken.encoding_for_model(model_name)
+        except Exception:  # pragma: no cover - unexpected model identifiers
+            try:
+                return tiktoken.get_encoding("cl100k_base")
+            except Exception:  # pragma: no cover - tiktoken misconfiguration
+                return None
+
+    def _resolve_context_window(self, model_name: Optional[str], override: Optional[object]) -> int:
+        if isinstance(override, str) and override.strip():
+            try:
+                value = int(override)
+                if value > 0:
+                    return value
+            except ValueError:
+                logger.warning("Invalid OPENAI_CONTEXT_WINDOW value '%s'; falling back to defaults", override)
+        elif isinstance(override, int) and override > 0:
+            return override
+
+        for known_model, window in _MODEL_CONTEXT_WINDOWS.items():
+            if model_name and known_model in model_name:
+                return window
+
+        return DEFAULT_CONTEXT_TOKEN_LIMIT
+
+
+def openai_sdk_available() -> bool:
+    """Return True when the OpenAI dependency is importable."""
+
+    return _OPENAI_AVAILABLE
+
+
+__all__ = ["OpenAIClient", "OpenAIIntegrationError", "openai_sdk_available"]
+

--- a/tests/unit/test_openai_client.py
+++ b/tests/unit/test_openai_client.py
@@ -1,0 +1,72 @@
+import sys
+import types
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "granite-test-generator" / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from integration import openai_client
+
+
+class _FakeResponses:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return types.SimpleNamespace(output_text="synthetic result")
+
+
+def _build_client(monkeypatch, *, context_window=256):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(openai_client, "_OPENAI_AVAILABLE", True, raising=False)
+
+    fake_responses = _FakeResponses()
+
+    class _FakeOpenAI:
+        def __init__(self, api_key):
+            self.api_key = api_key
+            self.responses = fake_responses
+
+    monkeypatch.setattr(openai_client, "OpenAI", _FakeOpenAI, raising=False)
+
+    client = openai_client.OpenAIClient(api_key="test-key", default_model="gpt-4o-mini")
+    client.max_context_tokens = context_window
+    return client, fake_responses
+
+
+def test_generate_response_truncates_prompt_when_exceeding_budget(monkeypatch):
+    client, responses = _build_client(monkeypatch, context_window=128)
+
+    long_prompt = "A" * 500
+    result = client.generate_response(long_prompt, max_output_tokens=40, model="gpt-4o-mini")
+
+    assert result == "synthetic result"
+    assert responses.calls, "OpenAI responses.create should be invoked"
+
+    request = responses.calls[0]
+    assert request["max_output_tokens"] <= 40
+    assert len(request["input"]) + request["max_output_tokens"] <= client.max_context_tokens
+    assert "[TRUNCATED" in request["input"]
+
+
+def test_generate_response_retains_prompt_within_budget(monkeypatch):
+    client, responses = _build_client(monkeypatch, context_window=512)
+
+    prompt = "short prompt"
+    result = client.generate_response(prompt, max_output_tokens=60)
+
+    assert result == "synthetic result"
+    request = responses.calls[0]
+    assert request["input"] == prompt
+    assert request["max_output_tokens"] == 60
+
+
+def test_count_tokens_works_without_tiktoken(monkeypatch):
+    client, _ = _build_client(monkeypatch, context_window=128)
+    monkeypatch.setattr(openai_client, "_TIKTOKEN_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(openai_client, "tiktoken", None, raising=False)
+
+    text = "token"
+    assert client.count_tokens(text) == len(text)


### PR DESCRIPTION
## Summary
- add token budget management to the OpenAI client with context window detection and graceful fallbacks when tiktoken is unavailable
- expose token counting utilities and truncate prompts to reserve completion budget before calling the Responses API
- cover the new behavior with unit tests and declare the optional tiktoken dependency

## Testing
- pytest tests/unit/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dc827046bc833286312f05a9144b5b